### PR TITLE
Housekeeping Updated

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -19,7 +19,7 @@ jobs:
 
   docsgen:
     needs: act
-    uses: jdowni000/arcaflow-docsgen/.github/workflows/reusable_workflow.yaml@poetry_version
+    uses: arcalot/arcaflow-docsgen/.github/workflows/reusable_workflow.yaml@main
     permissions:
       contents: write
       pull-requests: write

--- a/tests/test_arcaflow_plugin_kubeconfig.py
+++ b/tests/test_arcaflow_plugin_kubeconfig.py
@@ -43,7 +43,7 @@ Q9EwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAANBAFYIFM27BDiG725d
 VkhRblkvZzeRHhcwtDOQTC9d8M/LymN2y0nHSlJCZm/Lo/aH8viSY1vi1GSHfDz7
 Tlfe8gs=
 -----END CERTIFICATE-----
-"""
+""" # notsecret
     EXPECTED_KEY = """-----BEGIN PRIVATE KEY-----
 MIIBVAIBADANBgkqhkiG9w0BAQEFAASCAT4wggE6AgEAAkEArr89f2kggSO/yaCB
 6EwIQeT6ZptBoX0ZvCMI+DpkCwqOS5fwRbj1nEiPnLbzDDgMU8KCPAMhI7JpYRlH
@@ -54,7 +54,7 @@ EQIgbyxwNpwtEgEtW8untBrA83iU2kWNRY/z7ap4LkuS+0sCIGe2E+0RmfqQsllp
 icMvM2E92YnykCNYn6TwwCQSJjRxAiEAo9MmaVlK7YdhSMPo52uJYzd9MQZJqhq+
 lB1ZGDx/ARE=
 -----END PRIVATE KEY-----
-"""
+""" # notsecret
 
     def get_kubeconfig_test_value(self, filename):
         with open(filename, "r") as f:


### PR DESCRIPTION
## Changes introduced with this PR

- Update docsgen workflow path from testing to main
- Add `# notsecret` to test keys to prevent infosec triggering. This is unproven but followed docs [here](https://source.redhat.com/departments/it/it-information-security/wiki/pattern_distribution_server#:~:text=SECRET_KEY%20%3D%20%22super%2Dsneaky%2Dsecret%22%20%23%20notsecret)

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).