### PR TITLE
GitHub CI Docker Compose Update

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,9 +12,9 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v4
       - name: Build image
-        run: docker-compose build
+        run: docker compose build
       - name: Run plugin
-        run: docker-compose up
+        run: docker compose up
       - name: Extract coverage data
         run: |
           docker create --name test quay.io/arcalot/arcaflow-plugin-kubeconfig:latest


### PR DESCRIPTION
## Changes introduced with this PR

Changes to fix removed `docker-compose` behavior in GitHub CI Runner computing environment.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).